### PR TITLE
Feature/telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Parking
 
-A simple example of running clustered processes and sharing state across them using a 𝛿-CRDT mechanism based on [this series of articles](https://metasyntactic.info/distributing-phoenix-part-1/).
+A simple example of running clustered processes and sharing state across them using a 𝛿-CRDT mechanism based on [this series of articles](https://metasyntactic.info/distributing-phoenix-part-1/) by Erik Reedstrom.
 
-The series wasn't completed by the original author's stated intent, but it's a concise and valuable run through the nuts-and-bolts of exploiting Elixir/BEAM clustering in Kubernetes, and also a nice introduction to CRDT mechanisms. Finally, it also is a decent example of how to use the runtime `Config` module in place of the compile-time `Mix.Config` and the Elixir 1.9+ release facility.
+It seems he originally planned on writing a longer series on the subject, but even with just the two articles it's a concise and valuable run through the nuts-and-bolts of exploiting Elixir/BEAM clustering in Kubernetes, and also a nice introduction to CRDT mechanisms. Finally, it also is a decent example of how to use the runtime `Config` module in place of the compile-time `Mix.Config` and the Elixir 1.9+ release facility.
 
 ## Requirements
 
@@ -41,14 +41,24 @@ Parking.Lot.track_entry("ABC 123", 1)
 ```elixir
 # On gary or harry
 DeltaCrdt.read(Parking.Lot.Crdt)
+Parking.Lot.track_exit("ABC 123", 1)
+Parking.Lot.track_entry("2FAST4U", 3)
 ```
+
+```elixir
+# Back on larry
+DeltaCrdt.read(Parking.Lot.Crdt)
+```
+
+All four gate GenServers are running on `larry`, so running the `track_exit` and `track_entry` commands on another node demonstrates the distributed nature of the app.
+
 If `larry` is killed at this point, the gates will distribute over the remaining two nodes.  The `read` command should be repeated to demonstrate that state was in fact shared across all the nodes.
 
 ## Features
 
 Since it's supposed to be a sandbox for developing good production-ready patterns and explaining the what and why, there's a specific documentation file for each:
 
-- [Telemetry](https://github.com/thatcherhubbard/parking/docs/TELEMETRY.md))
+- [Telemetry](https://github.com/thatcherhubbard/parking/docs/TELEMETRY.md)
 
 ## Interesting things to add
 
@@ -56,8 +66,8 @@ Since it's supposed to be a sandbox for developing good production-ready pattern
 - Try replacing `Config` with `Vapor`
 - Write actual tests
 - Write a Helm chart
-- Add a `Telemetry` implementation
+- ~~Add a `Telemetry` implementation~~ Write useful telemetry instrumenters
 - Replace the eventually-consistent CRDT implementation with something based on [Raft](https://github.com/rabbitmq/ra) that won't return a value until there is consensus inside the cluster
-- Write a load-testing/benchmarking suite and corresponding telemetry updates
-- Implement a fanout mechanism (e.g [Manifold](https://github.com/discordapp/manifold)
+- Write a load-testing/benchmarking suite and corresponding telemetry updates (e.g [Benchfella](https://github.com/alco/benchfella))
+- Implement a fanout mechanism (e.g [Manifold](https://github.com/discordapp/manifold))
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 A simple example of running clustered processes and sharing state across them using a 𝛿-CRDT mechanism based on [this series of articles](https://metasyntactic.info/distributing-phoenix-part-1/).
 
-The series wasn't completed by the original author's stated intent, but it's a pretty concise run through the nuts-and-bolts of exploiting Elixir/BEAM clustering in Kubernetes, and also a nice introduction to CRDT mechanisms. Finally, it also is a decent example of how to use the runtime `Config` module in place of the compile-time `Mix.Config` and the Elixir 1.9+ release facility.
+The series wasn't completed by the original author's stated intent, but it's a concise and valuable run through the nuts-and-bolts of exploiting Elixir/BEAM clustering in Kubernetes, and also a nice introduction to CRDT mechanisms. Finally, it also is a decent example of how to use the runtime `Config` module in place of the compile-time `Mix.Config` and the Elixir 1.9+ release facility.
 
 ## Requirements
 
 No DB or anything required, it's basically:
 
 - Elixir (1.9.4 was the version developed against)
+
+If you want to actually build a release and deploy it to a Kubernetes cluster:
+
 - Minikube (1.6.2 running K8S 1.16.0 was the version developed against)
 
 ## Configuration
@@ -41,6 +44,12 @@ DeltaCrdt.read(Parking.Lot.Crdt)
 ```
 If `larry` is killed at this point, the gates will distribute over the remaining two nodes.  The `read` command should be repeated to demonstrate that state was in fact shared across all the nodes.
 
+## Features
+
+Since it's supposed to be a sandbox for developing good production-ready patterns and explaining the what and why, there's a specific documentation file for each:
+
+- [Telemetry](https://github.com/thatcherhubbard/parking/docs/TELEMETRY.md))
+
 ## Interesting things to add
 
 - Use `Config` to get the values for the number of gates and the number at runtime
@@ -50,5 +59,5 @@ If `larry` is killed at this point, the gates will distribute over the remaining
 - Add a `Telemetry` implementation
 - Replace the eventually-consistent CRDT implementation with something based on [Raft](https://github.com/rabbitmq/ra) that won't return a value until there is consensus inside the cluster
 - Write a load-testing/benchmarking suite and corresponding telemetry updates
-- Implement a fanout mechanism (e.g [Manifold](https://github.com/thatcherhubbard/parking))
+- Implement a fanout mechanism (e.g [Manifold](https://github.com/discordapp/manifold)
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -14,6 +14,13 @@ config :parking, ParkingWeb.Endpoint,
   render_errors: [view: ParkingWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: Parking.PubSub, adapter: Phoenix.PubSub.PG2]
 
+# Configures the telemetry endpoint
+config :parking, Parking.Telemetry.Endpoint,
+  http: [port: 9102],
+  debug_errors: true,
+  code_reloader: true,
+  check_origin: false
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -1,5 +1,16 @@
 import Config
 
+metrics_port = String.to_integer(System.fetch_env!("METRICS_PORT"))
+url = System.fetch_env!("APPLICATION_HOST")
+
 config :parking, ParkingWeb.Endpoint,
   http: [:inet6, port: System.fetch_env!("PORT")],
   secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
+
+config :parking, Parking.Telemetry.Endpoint,
+  url: [host: url],
+  http: [port: metrics_port],
+  secret_key_base: secret_key_base,
+  debug_errors: false,
+  server: true,
+  check_origin: false

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,0 +1,45 @@
+# Parking Telemetry
+
+This of course uses the Elixir `Telemetry` package, but there are a couple of differences from most of the examples of its use available online.  This is mainly in the interest of keeping the code clean and also running a separate endpoint for telemetry so it's easier to configure and secure in the contenxt of a K8S cluster.
+
+The `Telemetry` package doesn't prescribe any specific method of exposing the telemetry data collected.  For the purposes of this project, the assumption is an endpoint that will get scraped by [Prometheus](https://prometheus.io/).  The K8S deployment resources will include annotations that tell a cluster-resident Prometheus to scrape the application containers and what port to scrape them on.
+
+## Directory structure
+
+What's in the repo is "experimental" as in, "I'm seeing if it makes any sense".  The `telemetry` directory is under `lib`, parallel to `parking` and `parking_web`.  It's a Phoenix endpoint of it's own, though it only has one page.
+
+The idea is to try this out versus having the telemetry code distributed around in the application directory.
+
+## Setup
+
+The first step is to make sure the dependecies are included in the project configuration.  So add the following to `deps` function in `mix.exs`:
+
+```elixir
+      {:prometheus, "~> 4.5"},
+      {:prometheus_ex, "~> 3.0"},
+      {:prometheus_phoenix, "~> 1.3"},
+      {:prometheus_plugs, "~> 1.1.5"},
+      {:prometheus_process_collector, "~> 1.4"},
+      {:telemetry, "~> 0.4.1"}
+```
+
+## Endpoint
+
+Because it has it's own endpoint, it needs a minimal set of files for Phoenix:
+
+- `endpoint.ex`
+- `router.ex`
+- `page_controller.ex`
+
+The router and page controller files are pretty self-explanatory. The endpoint file is straigtforward, but there are a few `plug` calls at the bottom that implement that actual `/metrics` endpoint.
+
+## Config
+
+Because it's a separate endpoint, there are entries in the Elixir config directory that need to be made. The important bit is the configuration of the `Parking.Telemetry.Endpoint` module.   This follows the normal pattern of static config values in the `dev.exs` file, with environment variable substitution set up in the `releases.exs` file.
+
+The main `application.ex` file also needs changes to start the metrics endpoint along with the main app.  The lines that accomplish this are pretty clearly commented.
+
+## Instrumenters
+
+This is where the actual implementation of specific measurements is done.  For the Phoenix metrics, it's a simple `use` command because Phoenix already has intruments built into it.  You'll need to wrap whatever event(s) you want to respond to in the proper function spec, but aside from matching a signature, you can do whatever you want.
+

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -43,3 +43,6 @@ The main `application.ex` file also needs changes to start the metrics endpoint 
 
 This is where the actual implementation of specific measurements is done.  For the Phoenix metrics, it's a simple `use` command because Phoenix already has intruments built into it.  You'll need to wrap whatever event(s) you want to respond to in the proper function spec, but aside from matching a signature, you can do whatever you want.
 
+## Distributed application considerations
+
+Telemetry events only get processed for the node on which they occurred.  So if three cars enter on three separate nodes, each nodes' `car_entry_event` counter will increment by 1.  

--- a/lib/parking/lot.ex
+++ b/lib/parking/lot.ex
@@ -31,10 +31,12 @@ defmodule Parking.Lot do
 
   def track_entry(license, gate_number) do
     GenServer.cast(__MODULE__, {:track_entry, license, gate_number})
+    :telemetry.execute([:lot_supervisor, :lot_status, :car_entry], %{}, %{})
   end
 
   def track_exit(license, gate_number) do
     GenServer.cast(__MODULE__, {:track_exit, license, gate_number})
+    :telemetry.execute([:lot_supervisor, :lot_status, :car_exit], %{}, %{})
   end
 
   def available_spaces(), do: GenServer.call(__MODULE__, :available_spaces)

--- a/lib/parking/lot.ex
+++ b/lib/parking/lot.ex
@@ -71,16 +71,14 @@ defmodule Parking.Lot do
 
     # Update CRDT and state
 
-    time = System.monotonic_time()
-
-    DeltaCrdt.mutate(@crdt, :remove, [{:vehicle, license}, time], :infinity)
+    DeltaCrdt.mutate(@crdt, :remove, [{:vehicle, license}])
     vehicles = state |> Map.get(:vehicles) |> Map.delete(license)
 
     {:noreply, %{state | vehicles: vehicles}}
   end
 
   def handle_info(:update_state, state) do
-    # Read CRDT stater and group by key type
+    # Read CRDT state and group by key type
     crdt_state =
       DeltaCrdt.read(@crdt)
       |> Enum.group_by(fn {{k, _}, _} -> k end, fn {{_, kv}, v} -> {kv, v} end)

--- a/lib/telemetry/endpoint.ex
+++ b/lib/telemetry/endpoint.ex
@@ -1,0 +1,36 @@
+defmodule Parking.Telemetry.Endpoint do
+  use Phoenix.Endpoint, otp_app: :parking
+
+  # Serve at "/" the static files from "priv/static" directory.
+  #
+  # You should set gzip to true if you are running phx.digest
+  # when deploying your static files in production.
+  plug Plug.Static,
+    at: "/",
+    from: :parking,
+    gzip: false,
+    only: ~w(css fonts images js favicon.ico robots.txt)
+
+  plug Plug.RequestId
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+
+  plug Plug.MethodOverride
+  plug Plug.Head
+
+  # The session will be stored in the cookie and signed,
+  # this means its contents can be read but not tampered with.
+  # Set :encryption_salt if you would also like to encrypt it.
+  plug Plug.Session,
+    store: :cookie,
+    key: "_parking_key",
+    signing_salt: "1gYzzVR0"
+
+  # Creates the /metrics endpoint for prometheus & collect stats
+  plug Parking.Telemetry.PrometheusExporter
+
+  plug Parking.Telemetry.Router
+end

--- a/lib/telemetry/lot_instrumenter.ex
+++ b/lib/telemetry/lot_instrumenter.ex
@@ -9,7 +9,8 @@ defmodule Parking.Telemetry.LotInstrumenter do
       [:lot_supervisor, :lot_status, :car_exit]
     ]
 
-    Gauge.declare(name: :used_spaces_count, help: "Spaces occupied")
+    Gauge.declare(name: :entry_event_count, help: "Total entry events")
+    Gauge.declare(name: :exit_event_count, help: "Total exit events")
 
     :telemetry.attach_many("lot-instrumenter", events, &handle_event/4, nil)
   end
@@ -24,7 +25,7 @@ defmodule Parking.Telemetry.LotInstrumenter do
         _metadata,
         _config
       ) do
-    Gauge.inc(name: :used_spaces_count)
+    Gauge.inc(name: :entry_event_count)
   end
 
   def handle_event(
@@ -33,6 +34,6 @@ defmodule Parking.Telemetry.LotInstrumenter do
         _metadata,
         _config
       ) do
-    Gauge.dec(name: :used_spaces_count)
+    Gauge.inc(name: :exit_event_count)
   end
 end

--- a/lib/telemetry/lot_instrumenter.ex
+++ b/lib/telemetry/lot_instrumenter.ex
@@ -1,0 +1,38 @@
+defmodule Parking.Telemetry.LotInstrumenter do
+  require Logger
+
+  use Prometheus.Metric
+
+  def setup do
+    events = [
+      [:lot_supervisor, :lot_status, :car_entry],
+      [:lot_supervisor, :lot_status, :car_exit]
+    ]
+
+    Gauge.declare(name: :used_spaces_count, help: "Spaces occupied")
+
+    :telemetry.attach_many("lot-instrumenter", events, &handle_event/4, nil)
+  end
+
+  @doc """
+  Uses a Gauge.inc because the calling function knows neither lot size nor
+  the current car count
+  """
+  def handle_event(
+        [:lot_supervisor, :lot_status, :car_entry],
+        _measurements,
+        _metadata,
+        _config
+      ) do
+    Gauge.inc(name: :used_spaces_count)
+  end
+
+  def handle_event(
+        [:lot_supervisor, :lot_status, :car_exit],
+        _measurements,
+        _metadata,
+        _config
+      ) do
+    Gauge.dec(name: :used_spaces_count)
+  end
+end

--- a/lib/telemetry/page_controller.ex
+++ b/lib/telemetry/page_controller.ex
@@ -1,0 +1,7 @@
+defmodule Parking.Telemetry.PageController do
+  use ParkingWeb, :controller
+
+  def index(conn, _params) do
+    json(conn, %{status: "ok"})
+  end
+end

--- a/lib/telemetry/phoenix_instrumenter.ex
+++ b/lib/telemetry/phoenix_instrumenter.ex
@@ -1,0 +1,5 @@
+defmodule Parking.Telemetry.PhoenixInstrumenter do
+  @moduledoc "Prometheus instrmenter for Phoenix"
+
+  use Prometheus.PhoenixInstrumenter
+end

--- a/lib/telemetry/prometheus_exporter.ex
+++ b/lib/telemetry/prometheus_exporter.ex
@@ -1,0 +1,5 @@
+defmodule Parking.Telemetry.PrometheusExporter do
+  @moduledoc "Prometheus instrmenter for Phoenix"
+
+  use Prometheus.PlugExporter
+end

--- a/lib/telemetry/router.ex
+++ b/lib/telemetry/router.ex
@@ -1,0 +1,14 @@
+defmodule Parking.Telemetry.Router do
+  use ParkingWeb, :router
+
+  pipeline :api do
+    plug :accepts, ["json"]
+  end
+
+  scope "/", Parking.Telemetry do
+    # Use the default browser stack
+    pipe_through :api
+
+    get "/", PageController, :index
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,12 @@ defmodule Parking.MixProject do
       app: :parking,
       version: "0.1.0",
       elixir: "~> 1.5",
+      releases: [
+        parking: [
+          applications: [parking: :permanent],
+          include_executables_for: [:unix]
+        ]
+      ],
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
@@ -40,7 +46,13 @@ defmodule Parking.MixProject do
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:gettext, "~> 0.11"},
       {:jason, "~> 1.0"},
-      {:plug_cowboy, "~> 2.0"}
+      {:plug_cowboy, "~> 2.0"},
+      {:prometheus, "~> 4.5"},
+      {:prometheus_ex, "~> 3.0"},
+      {:prometheus_phoenix, "~> 1.3"},
+      {:prometheus_plugs, "~> 1.1.5"},
+      {:prometheus_process_collector, "~> 1.4"},
+      {:telemetry, "~> 0.4.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "accept": {:hex, :accept, "0.3.5", "b33b127abca7cc948bbe6caa4c263369abf1347cfa9d8e699c6d214660f10cd1", [:rebar3], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.7.0", "91ed100138a764355f43316b1d23d7ff6bdb0de4ea618cb5d8677c93a7a2f115", [:rebar3], [{:cowlib, "~> 2.8.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.8.0", "fd0ff1787db84ac415b8211573e9a30a3ebe71b5cbff7f720089972b2319c8a4", [:rebar3], [], "hexpm"},
   "delta_crdt": {:hex, :delta_crdt, "0.5.10", "e866f8d1b89bee497a98b9793e9ba0ea514112a1c41a0c30dcde3463d4984d14", [:mix], [{:merkle_map, "~> 0.2.0", [hex: :merkle_map, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
@@ -17,6 +18,11 @@
   "plug": {:hex, :plug, "1.8.3", "12d5f9796dc72e8ac9614e94bda5e51c4c028d0d428e9297650d09e15a684478", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm"},
   "plug_cowboy": {:hex, :plug_cowboy, "2.1.0", "b75768153c3a8a9e8039d4b25bb9b14efbc58e9c4a6e6a270abff1cd30cbe320", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
+  "prometheus": {:hex, :prometheus, "4.5.0", "8f4a2246fe0beb50af0f77c5e0a5bb78fe575c34a9655d7f8bc743aad1c6bf76", [:mix, :rebar3], [], "hexpm"},
+  "prometheus_ex": {:hex, :prometheus_ex, "3.0.5", "fa58cfd983487fc5ead331e9a3e0aa622c67232b3ec71710ced122c4c453a02f", [:mix], [{:prometheus, "~> 4.0", [hex: :prometheus, repo: "hexpm", optional: false]}], "hexpm"},
+  "prometheus_phoenix": {:hex, :prometheus_phoenix, "1.3.0", "c4b527e0b3a9ef1af26bdcfbfad3998f37795b9185d475ca610fe4388fdd3bb5", [:mix], [{:phoenix, "~> 1.4", [hex: :phoenix, repo: "hexpm", optional: false]}, {:prometheus_ex, "~> 1.3 or ~> 2.0 or ~> 3.0", [hex: :prometheus_ex, repo: "hexpm", optional: false]}], "hexpm"},
+  "prometheus_plugs": {:hex, :prometheus_plugs, "1.1.5", "25933d48f8af3a5941dd7b621c889749894d8a1082a6ff7c67cc99dec26377c5", [:mix], [{:accept, "~> 0.1", [hex: :accept, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}, {:prometheus_ex, "~> 1.1 or ~> 2.0 or ~> 3.0", [hex: :prometheus_ex, repo: "hexpm", optional: false]}, {:prometheus_process_collector, "~> 1.1", [hex: :prometheus_process_collector, repo: "hexpm", optional: true]}], "hexpm"},
+  "prometheus_process_collector": {:hex, :prometheus_process_collector, "1.4.5", "9baea93f5d8c2758dbad0de021ef74438d2f81a01d1f24f5ef0bb949a7b4191d", [:rebar3], [{:prometheus, "~> 4.0", [hex: :prometheus, repo: "hexpm", optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
   "telemetry_poller": {:hex, :telemetry_poller, "0.4.1", "50d03d976a3b8ab4898d9e873852e688840df47685a13af90af40e1ba43a758b", [:rebar3], [{:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
The `Telemetry` package is integrated and presents a couple of example metrics (in addition to canned BEAM VM stats) on the `localhost:9102/metrics` path for Prometheus to scrape.  